### PR TITLE
feat: 会員取得のエラーハンドリングの追加とCORS設定の追加

### DIFF
--- a/backend/crud/member_crud.py
+++ b/backend/crud/member_crud.py
@@ -22,7 +22,7 @@ def get_members():
 
 def get_member(member_id: str):
     res = table.get_item(Key={"PK": f"member#{member_id}", "SK": "profile"})
-    return res.get("Item", {})
+    return res.get("Item")
 
 
 def update_member(member_id: str, data: dict):

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,18 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from mangum import Mangum
 
 from routers import members, sessions, trainers
 
 app = FastAPI(redirect_slashes=False)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 handler = Mangum(app)
 
 app.include_router(members.router)

--- a/backend/routers/members.py
+++ b/backend/routers/members.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from crud import member_crud
 from uuid import uuid4
 from models.member import MemberCreate, MemberResponse, MemberUpdate
@@ -18,7 +18,10 @@ def get_members():
 
 @router.get("/{member_id}", response_model=MemberResponse)
 def get_member(member_id: str):
-    return member_crud.get_member(member_id)
+    member = member_crud.get_member(member_id)
+    if not member:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return member
 
 
 @router.post("")


### PR DESCRIPTION
## 概要                                                                        
  フロントエンド接続前の最低限のバックエンド追加。404ハンドリングとCORS設定。  
                                                                                 
  ## 実装内容                                                                    
  - GET /members/{member_id} に404ハンドリング追加                               
  - CORSMiddleware追加（localhost:3000許可）                                     
                                                                                 
  Closes #11 